### PR TITLE
plugins/zfunctions: fallback to $EDITOR if $VISUAL is not set

### DIFF
--- a/plugins/zfunctions/functions/funced
+++ b/plugins/zfunctions/functions/funced
@@ -51,7 +51,7 @@ eos
 fi
 
 # open the function file
-if [[ -z "$VISUAL" ]]; then
+if [[ ! -z "$VISUAL" ]]; then
   $VISUAL "$ZFUNCDIR/$1"
 else
   ${EDITOR:-vim} "$ZFUNCDIR/$1"

--- a/plugins/zfunctions/functions/funced
+++ b/plugins/zfunctions/functions/funced
@@ -51,7 +51,7 @@ eos
 fi
 
 # open the function file
-if [[ ! -z "$VISUAL" ]]; then
+if [[ -n "$VISUAL" ]]; then
   $VISUAL "$ZFUNCDIR/$1"
 else
   ${EDITOR:-vim} "$ZFUNCDIR/$1"


### PR DESCRIPTION
Hi there!
I was trying to use plugins/functions and encountered the following;
```zsh
~
❯ function testingstuff(){ echo hi }

~
❯ funcsave testingstuff

~
❯ funced testingstuff
funced:54: permission denied: /Users/selman/.config/zsh/functions/testingstuff

~
❯ VISUAL=ls funced testingstuff
# spawns $EDITOR
~
```

https://github.com/mattmc3/zephyr/blob/9e94963fc0934ab87a65d1b60de0fe628748b535/plugins/zfunctions/functions/funced#L53-L58

Felt like the check should be negated.

Feel free to close if it was intentional.

----

Thanks for the project!
