### PR TITLE
Add option 'use-block-cursor' to editor plugin

### DIFF
--- a/plugins/editor/editor.plugin.zsh
+++ b/plugins/editor/editor.plugin.zsh
@@ -100,6 +100,10 @@ function update-cursor-style {
     return
   fi
 
+  if zstyle -t ':zephyr:plugin:editor' use-block-cursor; then
+    return
+  fi
+
   if bindkey -lL main | grep viins > /dev/null; then
     # For vi-mode we
     case $KEYMAP in


### PR DESCRIPTION
I like your stuff, but I also like block cursor, and `use-block-cursor` (which defaults to `false`) enabled me to do so 🙏 