### PR TITLE
editor: make magic-enter opt-out

### DIFF
--- a/plugins/editor/editor.plugin.zsh
+++ b/plugins/editor/editor.plugin.zsh
@@ -252,7 +252,7 @@ function magic-enter {
 
 # Wrapper for the accept-line zle widget (run when pressing Enter)
 # If the wrapper already exists don't redefine it
-if (( ! ${+functions[_magic-enter_accept-line]} )); then
+if (( ! ${+functions[_magic-enter_accept-line]} )) && zstyle -t ':zephyr:plugin:editor' magic-enter; then
   case "$widgets[accept-line]" in
     # Override the current accept-line widget, calling the old one
     user:*) zle -N _magic-enter_orig_accept-line "${widgets[accept-line]#user:}"


### PR DESCRIPTION
I added a check for magic-enter zstyle. I believe this was the intended behavior based on this file:
#### [runcoms/zstyles.zsh](https://github.com/mattmc3/zephyr/blob/b1ab87c74ec047cbd11d70446fd65a527a6d3472/runcoms/zstyles.zsh)
```zsh
# Set the default (magic) command when hitting enter on an empty prompt.
# zstyle ':zephyr:plugin:editor' magic-enter 'yes'
```