### PR TITLE
fix(utility): prevent ls --group-directories-first on freebsd

### DIFF
--- a/plugins/utility/utility.plugin.zsh
+++ b/plugins/utility/utility.plugin.zsh
@@ -23,7 +23,7 @@ zle -N self-insert url-quote-magic
 alias help=run-help
 
 # Make ls more useful.
-if (( ! $+commands[dircolors] )) && [[ "$OSTYPE" != darwin* ]]; then
+if (( ! $+commands[dircolors] )) && [[ "$OSTYPE" != (darwin*|*bsd*) ]]; then
   # Group dirs first on non-BSD systems
   alias ls="${aliases[ls]:-ls} --group-directories-first"
 fi


### PR DESCRIPTION
Alternately, we could import bootstrap and use the `is-bsd` function from helpers, but since the utility plugin doesn't currently have that dependency I was reluctant to add it.