### PR TITLE
add option to always use prompt regardless of TERM env var

### DIFF
--- a/plugins/prompt/README.md
+++ b/plugins/prompt/README.md
@@ -51,4 +51,8 @@ To cache the prompt initialization:
 
 `zstyle ':zephyr:plugin:prompt' 'use-cache' 'yes'`
 
+To always use the prompt, regardless of terminal type:
+
+`zstyle ':zephyr:plugin:prompt' 'always-use-prompt' 'yes'`
+
 [16.2.8]: https://zsh.sourceforge.io/Doc/Release/Options.html#Prompting

--- a/plugins/prompt/prompt.plugin.zsh
+++ b/plugins/prompt/prompt.plugin.zsh
@@ -82,7 +82,14 @@ function run_promptinit {
   zstyle -a ':zephyr:plugin:prompt' theme 'prompt_argv' \
     || prompt_argv=(starship zephyr)
   if [[ $TERM == (dumb|linux|*bsd*) ]]; then
-    prompt 'off'
+  	zstyle -b ':zephyr:plugin:prompt' 'always-use-theme' 'autheme'
+  	if [[ $autheme == "yes" ]]; then
+  	  if (( $#prompt_argv > 0 )); then
+  	    prompt "$prompt_argv[@]"
+	  fi
+	else
+      prompt 'off'
+    fi
   elif (( $#prompt_argv > 0 )); then
     prompt "$prompt_argv[@]"
   fi


### PR DESCRIPTION
Some prompts that use ASCII work perfectly fine in terminals like the console. This PR just adds an option to reenable them there (and in `dumb|*bsd*` terminals).

The zstyle name is intentionally a bit long, so that hopefully it's a bit more clear what it does just from looking at it. I'm not terribly happy with it though, so if you think there's a better name, I'll definitely go with that.
